### PR TITLE
Do not read layout from base dir, and use tokens from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,12 @@ theme: minima
 plugins:
   - jekyll-feed
 
+# Settings for your Storyblok space
+storyblok:
+  token:   "qR6GM4L0j1w4h2fFZiZ28Qtt"
+  # Can be either `draft` or `published`
+  version: draft
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_plugins/storyblok_page.rb
+++ b/_plugins/storyblok_page.rb
@@ -29,19 +29,31 @@ module Jekyll
     safe true
 
     def generate(site)
-      client = ::Storyblok::Client.new(token: 'qR6GM4L0j1w4h2fFZiZ28Qtt', version: 'draft')
-      res = client.stories
-      stories = res['data']['stories']
+      @storyblok_config = site.config['storyblok']
+      raise 'Missing Storyblok configuration in _config.yml' unless @storyblok_config
 
-      res_links = client.links
-      links = res_links['data']['links']
+      links = client.links['data']['links']
+      stories = client.stories['data']['stories']
 
       stories.each do |story|
-        site.pages << StoryblokPage.new(site, site.source, story['full_slug'], story, links)
+        create_page(site, story, links)
+      end
+    end
 
-        if story['full_slug'] == 'home'
-          site.pages << StoryblokPage.new(site, site.source, '', story, links)
-        end
+    private
+
+    def client
+      @client ||= ::Storyblok::Client.new(
+        token: @storyblok_config['token'],
+        version: @storyblok_config['version']
+      )
+    end
+
+    def create_page(site, story, links)
+      site.pages << StoryblokPage.new(site, site.source, story['full_slug'], story, links)
+
+      if story['full_slug'] == 'home'
+        site.pages << StoryblokPage.new(site, site.source, '', story, links)
       end
     end
   end

--- a/_plugins/storyblok_page.rb
+++ b/_plugins/storyblok_page.rb
@@ -1,7 +1,6 @@
 require "storyblok"
 
 module Jekyll
-
   class StoryblokPage < Page
     def initialize(site, base, dir, story, links)
       @site = site
@@ -13,12 +12,16 @@ module Jekyll
       layout = story['content']['component']
 
       self.process(@name)
-      self.read_yaml(File.join(base, '_layouts'), layout + '.html')
+      # Jekyll provides the processed layouts in the site.layouts hash, so we
+      # will use it here!
+      # This makes it possible to use gem-based Jekyll themes.
+      self.data    = site.layouts[layout].data.dup
+      self.content = site.layouts[layout].content.dup
 
       # Assign the received data from the Storyblok API as variables
-      self.data['story']   = story
-      self.data['title']   = story['name']
-      self.data['links']   = links
+      self.data['story'] = story
+      self.data['title'] = story['name']
+      self.data['links'] = links
     end
   end
 


### PR DESCRIPTION
Here are two things I've changed for my own Jekyll-based website:

## Do not read layout from base dir

My Jekyll website uses two (private) gems I wrote: one for the theme and one for the plugins.  Since I'm using a gem-based theme, the layouts are not in the `_layouts` directory of the actual site, which breaks the `read_yaml`-based approach.  Welp.

Jekyll already loads all available layouts and stores them inside the `site.layouts` hash using `read_yaml`, so we can just perform a lookup for the layout we want to have and assign both the `data` and the `content` to `self`.  (This is actually what the `read_yaml` method does: https://github.com/jekyll/jekyll/blob/cebcff14120f8365feaf4bbabfa5ebd50b5704c6/lib/jekyll/convertible.rb#L46-L47)

So, yay for both site-local themes/layouts and gem-based ones are working now!

## Move client configuration to `_config.yml`

Should be pretty much self-explanatory, instead of storing the tokens inside the plugin itself it is now stored inside the site's `_config.yml`.

I also refactored the `Jekyll::StoryblokPageGenerator#generate` method a bit, just for fun.  ¯\\\_(ツ)\_/¯ 